### PR TITLE
Exclude box.zip from module build artifact

### DIFF
--- a/build/Build.cfc
+++ b/build/Build.cfc
@@ -17,6 +17,7 @@ component {
 
 		// Source Excludes Not Added to final binary
 		variables.excludes = [
+			"box.zip",
 			"build",
 			"node-modules",
 			"resources",


### PR DESCRIPTION
Exclude `box.zip` by default from the generated artifact. Helps minimize the generated artifact file, just in case the github action forgets to remove it.